### PR TITLE
fix: warn when requests fail silently under on_error="null"

### DIFF
--- a/polars_api/api.py
+++ b/polars_api/api.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import re
 import time
+import warnings
 from typing import Any, Callable, Optional, Union
 
 import aiohttp
@@ -133,23 +134,6 @@ def _parse_link_next(link_header: Optional[str]) -> Optional[str]:
             match = re.match(r"\s*<([^>]+)>", part)
             if match:
                 return match.group(1)
-    return None
-
-
-def _resolve_output(
-    result: dict[str, Any],
-    *,
-    with_metadata: bool,
-    on_error: OnError,
-) -> Any:
-    if with_metadata:
-        return result
-    if result["error"] is None:
-        return result["body"]
-    if on_error == "raise":
-        raise RuntimeError(result["error"])
-    if on_error == "return":
-        return result["body"]
     return None
 
 
@@ -601,6 +585,7 @@ class Api:
         if with_metadata:
             return pl.Series(results, dtype=_metadata_dtype(with_response_headers))
         out: list[Optional[str]] = []
+        silent_errors: list[str] = []
         for r in results:
             if r["error"] is None:
                 out.append(_coerce_body(r["body"]))
@@ -610,6 +595,15 @@ class Api:
                 out.append(_coerce_body(r["body"]))
             else:
                 out.append(None)
+                silent_errors.append(r["error"])
+        if silent_errors:
+            warnings.warn(
+                f"polars-api: {len(silent_errors)}/{len(results)} request(s) failed and "
+                f"were replaced with null (first error: {silent_errors[0]}). "
+                "Pass with_metadata=True to inspect per-row errors, or "
+                "on_error='raise'/'return' to change handling.",
+                stacklevel=2,
+            )
         return pl.Series(out, dtype=pl.Utf8)
 
     @staticmethod

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -422,7 +422,7 @@ def test_silent_null_failure_warns(monkeypatch: pytest.MonkeyPatch) -> None:
     """A column of nulls from unreachable URLs should not be silent — emit a warning."""
 
     def handler(req: httpx.Request) -> httpx.Response:
-        raise httpx.ConnectError("name resolution failed")
+        raise httpx.ConnectError("boom")
 
     _patch_sync(monkeypatch, handler)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from typing import Any, Callable, Optional, Union
 from urllib.parse import urlparse
 
@@ -415,6 +416,55 @@ def test_connection_error_returns_null(monkeypatch: pytest.MonkeyPatch) -> None:
     assert row["body"] is None
     assert row["error"] is not None
     assert "ConnectError" in row["error"]
+
+
+def test_silent_null_failure_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A column of nulls from unreachable URLs should not be silent — emit a warning."""
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("name resolution failed")
+
+    _patch_sync(monkeypatch, handler)
+
+    df = pl.DataFrame({"url": ["http://nope.invalid/a", "http://nope.invalid/b"]})
+    with pytest.warns(UserWarning, match=r"2/2 request\(s\) failed"):
+        out = df.with_columns(pl.col("url").api.get().alias("r"))
+
+    assert out["r"].to_list() == [None, None]
+
+
+def test_silent_null_failure_warns_async(monkeypatch: pytest.MonkeyPatch) -> None:
+    import aiohttp
+
+    def handler(method: str, url: str, kwargs: dict[str, Any]) -> BaseException:
+        return aiohttp.ClientConnectionError(f"cannot connect to {url}")
+
+    _patch_async(monkeypatch, handler)
+
+    df = pl.DataFrame({"url": ["http://nope.invalid/a"]})
+    with pytest.warns(UserWarning, match=r"1/1 request\(s\) failed"):
+        out = df.with_columns(pl.col("url").api.aget().alias("r"))
+
+    assert out["r"].to_list() == [None]
+
+
+def test_no_warning_when_with_metadata(monkeypatch: pytest.MonkeyPatch) -> None:
+    """with_metadata=True surfaces errors per row, so no warning is needed."""
+    _patch_sync(monkeypatch, lambda req: httpx.Response(500, text="boom"))
+
+    df = pl.DataFrame({"url": ["http://x/a"]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        df.with_columns(pl.col("url").api.get(with_metadata=True).alias("r"))
+
+
+def test_no_warning_when_on_error_return(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_sync(monkeypatch, lambda req: httpx.Response(404, text="missing"))
+
+    df = pl.DataFrame({"url": ["http://x/a"]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        df.with_columns(pl.col("url").api.get(on_error="return").alias("r"))
 
 
 def test_custom_sync_client_is_used() -> None:


### PR DESCRIPTION
When a URL was unreachable (or any request errored), the default
on_error="null" path silently filled the column with nulls — users only
discovered the failure by re-running with with_metadata=True. Now emit
a UserWarning summarizing how many rows failed and the first error, so
the failure mode is discoverable without changing default semantics.

Also drop the unused _resolve_output helper.