### PR TITLE
fix null value in param field for async

### DIFF
--- a/polars_api/api.py
+++ b/polars_api/api.py
@@ -193,7 +193,7 @@ class Api:
         if params is not None:
             # aiohttp's params accept str/int/float values; coerce non-strings
             # so behaviour matches httpx.
-            kwargs["params"] = {k: v if isinstance(v, str) else str(v) for k, v in params.items()}
+            kwargs["params"] = {k: v if isinstance(v, str) else str(v) for k, v in params.items() if v is not None}
         if headers is not None:
             kwargs["headers"] = headers
         if body is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -158,6 +158,26 @@ def test_aget_failure_returns_null(monkeypatch: pytest.MonkeyPatch) -> None:
     assert out["res"].to_list() == [None, None]
 
 
+def test_aget_omits_null_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A null param value must be dropped, not coerced to the string "None" (async path)."""
+    seen: list[dict[str, Any]] = []
+
+    def handler(method: str, url: str, kwargs: dict[str, Any]) -> _FakeAioResponse:
+        seen.append(kwargs.get("params"))
+        return _FakeAioResponse(200, "ok")
+
+    _patch_async(monkeypatch, handler)
+
+    df = pl.DataFrame({"url": ["http://x/a", "http://x/b"]}).with_columns(
+        pl.struct(userId=pl.Series([1, 2]), opt=pl.Series([None, None], dtype=pl.Int64)).alias("params"),
+    )
+    out = df.with_columns(pl.col("url").api.aget(params=pl.col("params")).alias("res"))
+
+    assert out["res"].to_list() == ["ok", "ok"]
+    # The null "opt" field is omitted entirely; no "opt": "None" leaks through.
+    assert sorted(seen, key=lambda p: p["userId"]) == [{"userId": "1"}, {"userId": "2"}]
+
+
 def test_apost_sends_json_body(monkeypatch: pytest.MonkeyPatch) -> None:
     seen: list[dict[str, Any]] = []
 


### PR DESCRIPTION
If a field in `params` contains null value (or None), then in async request, it is being sent as "None" string instead of omitting that field.
Sync request is working fine.