### PR TITLE
feat: add global defaults for request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,49 @@ pl.col("url").api.get(timeout=5.0)
 pl.col("url").api.apost(body=pl.col("body"), timeout=10.0)
 ```
 
+### 6. Global defaults (set options once)
+
+Talking to an authenticated API means passing the same `client=`, `bearer=`, or
+`auth=` to *every* call. Register them once with `set_defaults(...)` and every
+subsequent `.api` call falls back to them for any argument you don't pass
+explicitly:
+
+```python
+import httpx
+import polars_api
+
+polars_api.set_defaults(
+    client=httpx.Client(
+        base_url="https://api.example.com",
+        headers={"Authorization": "Bearer my-token"},
+    ),
+    retries=3,
+    backoff=0.5,
+)
+
+# No need to repeat client=/retries=/backoff= on each call:
+df.with_columns(pl.col("path").api.get().alias("res"))
+```
+
+Explicit per-call arguments always win over the configured default. Use the
+`defaults(...)` context manager to scope overrides to a block, and
+`reset_defaults()` to clear them:
+
+```python
+# Scope a client to one block; previous defaults are restored on exit
+with polars_api.defaults(client=session, max_concurrency=10):
+    df.with_columns(pl.col("path").api.aget().alias("res"))
+
+polars_api.reset_defaults()            # clear everything
+polars_api.reset_defaults("client")    # clear just one option
+polars_api.get_defaults()              # inspect the current config
+```
+
+> **Note:** `client` is shared across the sync (`httpx.Client`) and async
+> (`aiohttp.ClientSession`) paths, which need different client types. If you mix
+> sync and async verbs, set `client` per call (or via `defaults(...)`) so each
+> path gets the right client.
+
 ## API reference
 
 All methods live under the `.api` namespace on any Polars expression that resolves to a URL string.
@@ -207,6 +250,24 @@ df.with_columns(
     pl.col("url").api.paginate(max_pages=20).alias("pages")
 ).explode("pages")
 ```
+
+### Global configuration
+
+Module-level helpers let you set request options once instead of repeating them
+on every call. Anything left unset on a call falls back to the configured
+default, then to the built-in default; explicit per-call arguments always win.
+
+| Function                       | Purpose                                                            |
+| ------------------------------ | ----------------------------------------------------------------- |
+| `polars_api.set_defaults(**o)` | Register persistent defaults for any request option.              |
+| `polars_api.get_defaults()`    | Return a copy of the currently configured defaults.               |
+| `polars_api.reset_defaults(*names)` | Clear all defaults, or only the named ones.                  |
+| `polars_api.defaults(**o)`     | Context manager that applies defaults within a block, then restores. |
+
+Configurable options mirror the per-call keyword arguments: `client`, `headers`,
+`timeout`, `retries`, `backoff`, `max_concurrency`, `cache`, `with_metadata`,
+`with_response_headers`, `on_error`, `on_request`, `on_response`, `auth`,
+`bearer`, `api_key`, and `api_key_header`.
 
 ## Benchmarks
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ pipeline you must use the expression form with an explicit dtype.
 ### 7. Global defaults (set options once)
 
 Talking to an authenticated API means passing the same `client=`, `bearer=`, or
-`auth=` to *every* call. Register them once with `set_defaults(...)` and every
+`auth=` to _every_ call. Register them once with `set_defaults(...)` and every
 subsequent `.api` call falls back to them for any argument you don't pass
 explicitly:
 
@@ -306,12 +306,12 @@ Module-level helpers let you set request options once instead of repeating them
 on every call. Anything left unset on a call falls back to the configured
 default, then to the built-in default; explicit per-call arguments always win.
 
-| Function                       | Purpose                                                            |
-| ------------------------------ | ----------------------------------------------------------------- |
-| `polars_api.set_defaults(**o)` | Register persistent defaults for any request option.              |
-| `polars_api.get_defaults()`    | Return a copy of the currently configured defaults.               |
-| `polars_api.reset_defaults(*names)` | Clear all defaults, or only the named ones.                  |
-| `polars_api.defaults(**o)`     | Context manager that applies defaults within a block, then restores. |
+| Function                            | Purpose                                                              |
+| ----------------------------------- | -------------------------------------------------------------------- |
+| `polars_api.set_defaults(**o)`      | Register persistent defaults for any request option.                 |
+| `polars_api.get_defaults()`         | Return a copy of the currently configured defaults.                  |
+| `polars_api.reset_defaults(*names)` | Clear all defaults, or only the named ones.                          |
+| `polars_api.defaults(**o)`          | Context manager that applies defaults within a block, then restores. |
 
 Configurable options mirror the per-call keyword arguments: `client`, `headers`,
 `timeout`, `retries`, `backoff`, `max_concurrency`, `cache`, `with_metadata`,

--- a/TODO.md
+++ b/TODO.md
@@ -18,6 +18,7 @@ A running list of features to consider for `polars-api`. Ordered roughly by valu
 - Lifecycle hooks: `on_request` / `on_response` callbacks. Sync verbs receive `httpx.Request` / `httpx.Response`; async verbs receive `(method, url, kwargs)` / `aiohttp.ClientResponse`.
 - Aiohttp-based async path: ~10× higher throughput than httpx at high concurrency.
 - Pagination helper: `paginate(...)` follows `Link: rel="next"` by default, accepts a custom `next_url=` callable, and returns `List[Utf8]` of bodies per row.
+- Global defaults: `set_defaults(...)` / `get_defaults()` / `reset_defaults(...)` and the `defaults(...)` context manager register request options (e.g. `client`, `auth`, `bearer`, `retries`) once instead of passing them on every call. Explicit per-call arguments always win.
 
 ## Remaining
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -23,6 +23,30 @@ import polars_api  # noqa: F401  — registers the `.api` namespace
 
 All methods return a `pl.Expr` of dtype `Utf8` containing the response body for each row. Use `.str.json_decode()` to parse JSON responses.
 
+## Global configuration
+
+Set request options once instead of passing them on every call. Anything left
+unset on a call falls back to the configured default, then the built-in default;
+explicit per-call arguments always take precedence.
+
+```python
+import httpx
+import polars_api
+
+polars_api.set_defaults(client=httpx.Client(base_url="https://api.example.com"))
+
+with polars_api.defaults(retries=3):
+    ...  # `.api` calls in here retry up to 3 times
+```
+
+::: polars_api.set_defaults
+
+::: polars_api.get_defaults
+
+::: polars_api.reset_defaults
+
+::: polars_api.defaults
+
 ## `polars_api.Api`
 
 ::: polars_api.api.Api

--- a/polars_api/__init__.py
+++ b/polars_api/__init__.py
@@ -1,3 +1,3 @@
-from .api import Api
+from .api import Api, defaults, get_defaults, reset_defaults, set_defaults
 
-__all__ = ["Api"]
+__all__ = ["Api", "defaults", "get_defaults", "reset_defaults", "set_defaults"]

--- a/polars_api/api.py
+++ b/polars_api/api.py
@@ -1,8 +1,11 @@
 import asyncio
 import base64
+import contextlib
 import re
+import threading
 import time
 import warnings
+from collections.abc import Iterator
 from typing import Any, Callable, Optional, Union
 
 import aiohttp
@@ -152,6 +155,167 @@ def _build_request_kwargs(
     if timeout is not None:
         kwargs["timeout"] = timeout
     return kwargs
+
+
+# ---- Global defaults ------------------------------------------------------
+#
+# Passing ``client=...`` (and friends) to every ``.api`` call is tedious when
+# every request in a pipeline hits the same authenticated API. ``set_defaults``
+# lets a user register option values once; every verb then falls back to them
+# for any argument left unset. Explicit per-call arguments always win.
+
+
+class _Unset:
+    """Sentinel for "argument not supplied" so we can tell it apart from an
+    explicit ``None`` and fall back to the configured global default."""
+
+    _instance: "Optional[_Unset]" = None
+
+    def __new__(cls) -> "_Unset":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return "UNSET"
+
+    def __bool__(self) -> bool:
+        return False
+
+
+UNSET = _Unset()
+
+# The options that may be configured globally. These mirror the keyword
+# arguments accepted by ``request`` / ``arequest`` / ``paginate`` (minus the
+# per-row data carriers ``params`` / ``body`` / ``data`` and pagination-only
+# knobs like ``max_pages`` / ``next_url``). Each maps to the value used when
+# the argument is neither passed explicitly nor configured globally.
+_OPTION_DEFAULTS: dict[str, Any] = {
+    "headers": None,
+    "client": None,
+    "timeout": None,
+    "retries": 0,
+    "backoff": 0.0,
+    "cache": False,
+    "with_metadata": False,
+    "with_response_headers": False,
+    "on_error": "null",
+    "on_request": None,
+    "on_response": None,
+    "auth": None,
+    "bearer": None,
+    "api_key": None,
+    "api_key_header": "X-API-Key",
+    "max_concurrency": None,
+}
+
+_DEFAULTS: dict[str, Any] = {}
+_DEFAULTS_LOCK = threading.Lock()
+
+
+def _check_option_names(options: dict[str, Any], where: str) -> None:
+    unknown = set(options) - set(_OPTION_DEFAULTS)
+    if unknown:
+        msg = (
+            f"Unknown option(s) for {where}: {', '.join(sorted(unknown))}. "
+            f"Valid options are: {', '.join(sorted(_OPTION_DEFAULTS))}."
+        )
+        raise ValueError(msg)
+
+
+def set_defaults(**options: Any) -> None:
+    """Register global default values for ``.api`` request options.
+
+    Any option accepted by ``get`` / ``post`` / ``aget`` / ``paginate`` etc. can
+    be set once here and is then applied to every subsequent call that does not
+    pass that argument explicitly. Explicit per-call arguments always take
+    precedence. This is most useful for the ``client`` argument when talking to
+    an authenticated API:
+
+    ```python
+    import httpx
+    import polars_api
+
+    polars_api.set_defaults(
+        client=httpx.Client(
+            base_url="https://api.example.com",
+            headers={"Authorization": "Bearer ..."},
+        ),
+    )
+    pl.col("path").api.get()  # uses the configured client automatically
+    ```
+
+    Note that ``client`` is shared across the sync (``httpx.Client``) and async
+    (``aiohttp.ClientSession``) paths, which require different client types. If
+    you mix sync and async verbs, prefer setting ``client`` per call (or use the
+    ``defaults`` context manager) so each path gets the right client.
+
+    Raises ``ValueError`` if an unknown option name is supplied.
+    """
+    _check_option_names(options, "set_defaults")
+    with _DEFAULTS_LOCK:
+        _DEFAULTS.update(options)
+
+
+def get_defaults() -> dict[str, Any]:
+    """Return a copy of the currently configured global defaults."""
+    with _DEFAULTS_LOCK:
+        return dict(_DEFAULTS)
+
+
+def reset_defaults(*options: str) -> None:
+    """Clear configured global defaults.
+
+    With no arguments, clears all of them. Pass option names to clear only
+    those:
+
+    ```python
+    polars_api.reset_defaults()           # clear everything
+    polars_api.reset_defaults("client")   # clear just `client`
+    ```
+    """
+    with _DEFAULTS_LOCK:
+        if not options:
+            _DEFAULTS.clear()
+            return
+        for name in options:
+            _DEFAULTS.pop(name, None)
+
+
+@contextlib.contextmanager
+def defaults(**options: Any) -> "Iterator[None]":
+    """Context manager that applies global defaults only within the block.
+
+    Restores the previous defaults on exit, so it composes with (and overrides)
+    any values set via ``set_defaults``:
+
+    ```python
+    with polars_api.defaults(client=session, retries=3):
+        df.with_columns(pl.col("path").api.aget().alias("res"))
+    ```
+
+    Raises ``ValueError`` if an unknown option name is supplied.
+    """
+    _check_option_names(options, "defaults")
+    with _DEFAULTS_LOCK:
+        previous = dict(_DEFAULTS)
+        _DEFAULTS.update(options)
+    try:
+        yield
+    finally:
+        with _DEFAULTS_LOCK:
+            _DEFAULTS.clear()
+            _DEFAULTS.update(previous)
+
+
+def _resolve(name: str, value: Any) -> Any:
+    """Resolve a single option: explicit value > global default > built-in default."""
+    if value is not UNSET:
+        return value
+    with _DEFAULTS_LOCK:
+        if name in _DEFAULTS:
+            return _DEFAULTS[name]
+    return _OPTION_DEFAULTS[name]
 
 
 @pl.api.register_expr_namespace("api")
@@ -753,40 +917,50 @@ class Api:
         body: Optional[pl.Expr] = None,
         *,
         data: Optional[pl.Expr] = None,
-        headers: Optional[pl.Expr] = None,
-        client: Optional[httpx.Client] = None,
-        timeout: Optional[float] = None,
-        retries: int = 0,
-        backoff: float = 0.0,
-        cache: bool = False,
-        with_metadata: bool = False,
-        with_response_headers: bool = False,
-        on_error: OnError = "null",
-        on_request: Optional[RequestHook] = None,
-        on_response: Optional[ResponseHook] = None,
-        auth: Optional[tuple[str, str]] = None,
-        bearer: Optional[Union[str, pl.Expr]] = None,
-        api_key: Optional[Union[str, pl.Expr]] = None,
-        api_key_header: str = "X-API-Key",
+        headers: Any = UNSET,
+        client: Any = UNSET,
+        timeout: Any = UNSET,
+        retries: Any = UNSET,
+        backoff: Any = UNSET,
+        cache: Any = UNSET,
+        with_metadata: Any = UNSET,
+        with_response_headers: Any = UNSET,
+        on_error: Any = UNSET,
+        on_request: Any = UNSET,
+        on_response: Any = UNSET,
+        auth: Any = UNSET,
+        bearer: Any = UNSET,
+        api_key: Any = UNSET,
+        api_key_header: Any = UNSET,
     ) -> pl.Expr:
-        """Issue a synchronous HTTP request per row."""
-        merged_headers = self._build_headers_expr(headers, auth, bearer, api_key, api_key_header)
+        """Issue a synchronous HTTP request per row.
+
+        Any argument left unset falls back to the value registered via
+        ``set_defaults`` (or the ``defaults`` context manager), then to the built-in default.
+        """
+        merged_headers = self._build_headers_expr(
+            _resolve("headers", headers),
+            _resolve("auth", auth),
+            _resolve("bearer", bearer),
+            _resolve("api_key", api_key),
+            _resolve("api_key_header", api_key_header),
+        )
         return self._sync_call(
             method.upper(),
             params,
             body,
             data,
             merged_headers,
-            client=client,
-            timeout=timeout,
-            retries=retries,
-            backoff=backoff,
-            cache=cache,
-            with_metadata=with_metadata,
-            with_response_headers=with_response_headers,
-            on_error=on_error,
-            on_request=on_request,
-            on_response=on_response,
+            client=_resolve("client", client),
+            timeout=_resolve("timeout", timeout),
+            retries=_resolve("retries", retries),
+            backoff=_resolve("backoff", backoff),
+            cache=_resolve("cache", cache),
+            with_metadata=_resolve("with_metadata", with_metadata),
+            with_response_headers=_resolve("with_response_headers", with_response_headers),
+            on_error=_resolve("on_error", on_error),
+            on_request=_resolve("on_request", on_request),
+            on_response=_resolve("on_response", on_response),
         )
 
     def arequest(
@@ -796,47 +970,57 @@ class Api:
         body: Optional[pl.Expr] = None,
         *,
         data: Optional[pl.Expr] = None,
-        headers: Optional[pl.Expr] = None,
-        client: Optional[aiohttp.ClientSession] = None,
-        timeout: Optional[float] = None,
-        retries: int = 0,
-        backoff: float = 0.0,
-        max_concurrency: Optional[int] = None,
-        cache: bool = False,
-        with_metadata: bool = False,
-        with_response_headers: bool = False,
-        on_error: OnError = "null",
-        on_request: Optional[AsyncRequestHook] = None,
-        on_response: Optional[AsyncResponseHook] = None,
-        auth: Optional[tuple[str, str]] = None,
-        bearer: Optional[Union[str, pl.Expr]] = None,
-        api_key: Optional[Union[str, pl.Expr]] = None,
-        api_key_header: str = "X-API-Key",
+        headers: Any = UNSET,
+        client: Any = UNSET,
+        timeout: Any = UNSET,
+        retries: Any = UNSET,
+        backoff: Any = UNSET,
+        max_concurrency: Any = UNSET,
+        cache: Any = UNSET,
+        with_metadata: Any = UNSET,
+        with_response_headers: Any = UNSET,
+        on_error: Any = UNSET,
+        on_request: Any = UNSET,
+        on_response: Any = UNSET,
+        auth: Any = UNSET,
+        bearer: Any = UNSET,
+        api_key: Any = UNSET,
+        api_key_header: Any = UNSET,
     ) -> pl.Expr:
-        """Issue concurrent asynchronous HTTP requests across the batch."""
-        merged_headers = self._build_headers_expr(headers, auth, bearer, api_key, api_key_header)
+        """Issue concurrent asynchronous HTTP requests across the batch.
+
+        Any argument left unset falls back to the value registered via
+        ``set_defaults`` (or the ``defaults`` context manager), then to the built-in default.
+        """
+        merged_headers = self._build_headers_expr(
+            _resolve("headers", headers),
+            _resolve("auth", auth),
+            _resolve("bearer", bearer),
+            _resolve("api_key", api_key),
+            _resolve("api_key_header", api_key_header),
+        )
         return self._async_call(
             method.upper(),
             params,
             body,
             data,
             merged_headers,
-            client=client,
-            timeout=timeout,
-            retries=retries,
-            backoff=backoff,
-            max_concurrency=max_concurrency,
-            cache=cache,
-            with_metadata=with_metadata,
-            with_response_headers=with_response_headers,
-            on_error=on_error,
-            on_request=on_request,
-            on_response=on_response,
+            client=_resolve("client", client),
+            timeout=_resolve("timeout", timeout),
+            retries=_resolve("retries", retries),
+            backoff=_resolve("backoff", backoff),
+            max_concurrency=_resolve("max_concurrency", max_concurrency),
+            cache=_resolve("cache", cache),
+            with_metadata=_resolve("with_metadata", with_metadata),
+            with_response_headers=_resolve("with_response_headers", with_response_headers),
+            on_error=_resolve("on_error", on_error),
+            on_request=_resolve("on_request", on_request),
+            on_response=_resolve("on_response", on_response),
         )
 
     # ---- Verb wrappers (sync) ----
 
-    def get(self, params: Optional[pl.Expr] = None, timeout: Optional[float] = None, **kwargs: Any) -> pl.Expr:
+    def get(self, params: Optional[pl.Expr] = None, timeout: Any = UNSET, **kwargs: Any) -> pl.Expr:
         """Issue a synchronous GET per row."""
         return self.request("GET", params, None, timeout=timeout, **kwargs)
 
@@ -844,7 +1028,7 @@ class Api:
         self,
         params: Optional[pl.Expr] = None,
         body: Optional[pl.Expr] = None,
-        timeout: Optional[float] = None,
+        timeout: Any = UNSET,
         **kwargs: Any,
     ) -> pl.Expr:
         """Issue a synchronous POST per row."""
@@ -854,7 +1038,7 @@ class Api:
         self,
         params: Optional[pl.Expr] = None,
         body: Optional[pl.Expr] = None,
-        timeout: Optional[float] = None,
+        timeout: Any = UNSET,
         **kwargs: Any,
     ) -> pl.Expr:
         """Issue a synchronous PUT per row."""
@@ -864,23 +1048,23 @@ class Api:
         self,
         params: Optional[pl.Expr] = None,
         body: Optional[pl.Expr] = None,
-        timeout: Optional[float] = None,
+        timeout: Any = UNSET,
         **kwargs: Any,
     ) -> pl.Expr:
         """Issue a synchronous PATCH per row."""
         return self.request("PATCH", params, body, timeout=timeout, **kwargs)
 
-    def delete(self, params: Optional[pl.Expr] = None, timeout: Optional[float] = None, **kwargs: Any) -> pl.Expr:
+    def delete(self, params: Optional[pl.Expr] = None, timeout: Any = UNSET, **kwargs: Any) -> pl.Expr:
         """Issue a synchronous DELETE per row."""
         return self.request("DELETE", params, None, timeout=timeout, **kwargs)
 
-    def head(self, params: Optional[pl.Expr] = None, timeout: Optional[float] = None, **kwargs: Any) -> pl.Expr:
+    def head(self, params: Optional[pl.Expr] = None, timeout: Any = UNSET, **kwargs: Any) -> pl.Expr:
         """Issue a synchronous HEAD per row."""
         return self.request("HEAD", params, None, timeout=timeout, **kwargs)
 
     # ---- Verb wrappers (async) ----
 
-    def aget(self, params: Optional[pl.Expr] = None, timeout: Optional[float] = None, **kwargs: Any) -> pl.Expr:
+    def aget(self, params: Optional[pl.Expr] = None, timeout: Any = UNSET, **kwargs: Any) -> pl.Expr:
         """Issue concurrent asynchronous GETs across the batch."""
         return self.arequest("GET", params, None, timeout=timeout, **kwargs)
 
@@ -888,7 +1072,7 @@ class Api:
         self,
         params: Optional[pl.Expr] = None,
         body: Optional[pl.Expr] = None,
-        timeout: Optional[float] = None,
+        timeout: Any = UNSET,
         **kwargs: Any,
     ) -> pl.Expr:
         """Issue concurrent asynchronous POSTs across the batch."""
@@ -898,7 +1082,7 @@ class Api:
         self,
         params: Optional[pl.Expr] = None,
         body: Optional[pl.Expr] = None,
-        timeout: Optional[float] = None,
+        timeout: Any = UNSET,
         **kwargs: Any,
     ) -> pl.Expr:
         """Issue concurrent asynchronous PUTs across the batch."""
@@ -908,17 +1092,17 @@ class Api:
         self,
         params: Optional[pl.Expr] = None,
         body: Optional[pl.Expr] = None,
-        timeout: Optional[float] = None,
+        timeout: Any = UNSET,
         **kwargs: Any,
     ) -> pl.Expr:
         """Issue concurrent asynchronous PATCHes across the batch."""
         return self.arequest("PATCH", params, body, timeout=timeout, **kwargs)
 
-    def adelete(self, params: Optional[pl.Expr] = None, timeout: Optional[float] = None, **kwargs: Any) -> pl.Expr:
+    def adelete(self, params: Optional[pl.Expr] = None, timeout: Any = UNSET, **kwargs: Any) -> pl.Expr:
         """Issue concurrent asynchronous DELETEs across the batch."""
         return self.arequest("DELETE", params, None, timeout=timeout, **kwargs)
 
-    def ahead(self, params: Optional[pl.Expr] = None, timeout: Optional[float] = None, **kwargs: Any) -> pl.Expr:
+    def ahead(self, params: Optional[pl.Expr] = None, timeout: Any = UNSET, **kwargs: Any) -> pl.Expr:
         """Issue concurrent asynchronous HEADs across the batch."""
         return self.arequest("HEAD", params, None, timeout=timeout, **kwargs)
 
@@ -931,17 +1115,17 @@ class Api:
         method: str = "GET",
         max_pages: int = 10,
         next_url: Optional[NextUrl] = None,
-        headers: Optional[pl.Expr] = None,
-        client: Optional[httpx.Client] = None,
-        timeout: Optional[float] = None,
-        retries: int = 0,
-        backoff: float = 0.0,
-        on_request: Optional[RequestHook] = None,
-        on_response: Optional[ResponseHook] = None,
-        auth: Optional[tuple[str, str]] = None,
-        bearer: Optional[Union[str, pl.Expr]] = None,
-        api_key: Optional[Union[str, pl.Expr]] = None,
-        api_key_header: str = "X-API-Key",
+        headers: Any = UNSET,
+        client: Any = UNSET,
+        timeout: Any = UNSET,
+        retries: Any = UNSET,
+        backoff: Any = UNSET,
+        on_request: Any = UNSET,
+        on_response: Any = UNSET,
+        auth: Any = UNSET,
+        bearer: Any = UNSET,
+        api_key: Any = UNSET,
+        api_key_header: Any = UNSET,
     ) -> pl.Expr:
         """Synchronously paginate per row, following Link: rel="next" by default.
 
@@ -951,8 +1135,23 @@ class Api:
 
         Pass `next_url=lambda response: ...` to extract the next URL from a custom
         location (e.g. a JSON field) instead of the Link header.
+
+        Any unset argument falls back to the value registered via
+        ``set_defaults`` (or the ``defaults`` context manager), then to the built-in default.
         """
-        merged_headers = self._build_headers_expr(headers, auth, bearer, api_key, api_key_header)
+        client = _resolve("client", client)
+        timeout = _resolve("timeout", timeout)
+        retries = _resolve("retries", retries)
+        backoff = _resolve("backoff", backoff)
+        on_request = _resolve("on_request", on_request)
+        on_response = _resolve("on_response", on_response)
+        merged_headers = self._build_headers_expr(
+            _resolve("headers", headers),
+            _resolve("auth", auth),
+            _resolve("bearer", bearer),
+            _resolve("api_key", api_key),
+            _resolve("api_key_header", api_key_header),
+        )
         params_expr = pl.lit(None) if params is None else params
         headers_expr = pl.lit(None) if merged_headers is None else merged_headers
         extractor = next_url or (lambda r: _parse_link_next(r.headers.get("link")))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,7 +8,15 @@ import polars as pl
 import pytest
 from multidict import CIMultiDict, CIMultiDictProxy
 
-import polars_api  # noqa: F401  registers the `api` namespace
+import polars_api
+
+
+@pytest.fixture(autouse=True)
+def _reset_global_defaults() -> Any:
+    """Global defaults are module-level state; keep tests isolated."""
+    polars_api.reset_defaults()
+    yield
+    polars_api.reset_defaults()
 
 
 # ---- sync mocking (httpx) ----
@@ -606,6 +614,138 @@ def test_paginate_max_pages_caps(monkeypatch: pytest.MonkeyPatch) -> None:
     out = df.with_columns(pl.col("url").api.paginate(max_pages=3).alias("pages"))
 
     assert len(out["pages"].to_list()[0]) == 3
+
+
+def test_set_defaults_applies_client() -> None:
+    transport = httpx.MockTransport(lambda req: httpx.Response(200, text="from-default"))
+    client = httpx.Client(transport=transport)
+    polars_api.set_defaults(client=client)
+
+    df = pl.DataFrame({"url": ["http://x/a", "http://x/b"]})
+    out = df.with_columns(pl.col("url").api.get().alias("r"))
+
+    assert out["r"].to_list() == ["from-default", "from-default"]
+    client.close()
+
+
+def test_explicit_arg_overrides_default() -> None:
+    default_transport = httpx.MockTransport(lambda req: httpx.Response(200, text="default"))
+    explicit_transport = httpx.MockTransport(lambda req: httpx.Response(200, text="explicit"))
+    default_client = httpx.Client(transport=default_transport)
+    explicit_client = httpx.Client(transport=explicit_transport)
+    polars_api.set_defaults(client=default_client)
+
+    df = pl.DataFrame({"url": ["http://x/a"]})
+    out = df.with_columns(pl.col("url").api.get(client=explicit_client).alias("r"))
+
+    assert out["r"].to_list() == ["explicit"]
+    default_client.close()
+    explicit_client.close()
+
+
+def test_set_defaults_applies_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen.append(req.headers.get("authorization", ""))
+        return httpx.Response(200, text="ok")
+
+    _patch_sync(monkeypatch, handler)
+    polars_api.set_defaults(auth=("alice", "s3cret"))
+
+    df = pl.DataFrame({"url": ["http://x/a"]})
+    df.with_columns(pl.col("url").api.get().alias("r")).collect_schema()
+
+    assert seen == ["Basic YWxpY2U6czNjcmV0"]
+
+
+def test_set_defaults_applies_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = {"calls": 0}
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        state["calls"] += 1
+        if state["calls"] < 3:
+            return httpx.Response(503, text="busy")
+        return httpx.Response(200, text="ok")
+
+    _patch_sync(monkeypatch, handler)
+    polars_api.set_defaults(retries=3, backoff=0.0)
+
+    df = pl.DataFrame({"url": ["http://x/a"]})
+    out = df.with_columns(pl.col("url").api.get().alias("r"))
+
+    assert out["r"].to_list() == ["ok"]
+    assert state["calls"] == 3
+
+
+def test_set_defaults_applies_to_async() -> None:
+    session = _FakeAioSession(lambda m, url, kw: _FakeAioResponse(200, f"hi:{_path(url)}"))
+    polars_api.set_defaults(client=session)
+
+    df = pl.DataFrame({"url": ["http://x/a", "http://x/b"]})
+    out = df.with_columns(pl.col("url").api.aget().alias("r"))
+
+    assert out["r"].to_list() == ["hi:/a", "hi:/b"]
+
+
+def test_get_defaults_returns_copy() -> None:
+    polars_api.set_defaults(retries=2)
+    snapshot = polars_api.get_defaults()
+    assert snapshot == {"retries": 2}
+    # Mutating the returned dict must not affect the live config.
+    snapshot["retries"] = 99
+    assert polars_api.get_defaults() == {"retries": 2}
+
+
+def test_reset_defaults_named_and_all() -> None:
+    polars_api.set_defaults(retries=2, backoff=0.5, cache=True)
+    polars_api.reset_defaults("retries")
+    assert polars_api.get_defaults() == {"backoff": 0.5, "cache": True}
+    polars_api.reset_defaults()
+    assert polars_api.get_defaults() == {}
+
+
+def test_defaults_context_manager_scopes_and_restores() -> None:
+    transport = httpx.MockTransport(lambda req: httpx.Response(200, text="scoped"))
+    client = httpx.Client(transport=transport)
+    polars_api.set_defaults(retries=1)
+
+    df = pl.DataFrame({"url": ["http://x/a"]})
+    with polars_api.defaults(client=client):
+        out = df.with_columns(pl.col("url").api.get().alias("r"))
+        assert out["r"].to_list() == ["scoped"]
+        # The pre-existing default is preserved alongside the scoped one.
+        assert polars_api.get_defaults() == {"retries": 1, "client": client}
+
+    # On exit, the scoped override is gone but the prior default remains.
+    assert polars_api.get_defaults() == {"retries": 1}
+    client.close()
+
+
+def test_set_defaults_rejects_unknown_option() -> None:
+    with pytest.raises(ValueError, match="Unknown option"):
+        polars_api.set_defaults(not_a_real_option=1)
+
+
+def test_defaults_context_manager_rejects_unknown_option() -> None:
+    with pytest.raises(ValueError, match="Unknown option"), polars_api.defaults(nope=1):
+        pass
+
+
+def test_set_defaults_applies_to_paginate(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[str] = []
+
+    def handler(req: httpx.Request) -> httpx.Response:
+        seen.append(req.headers.get("authorization", ""))
+        return httpx.Response(200, text="page")
+
+    _patch_sync(monkeypatch, handler)
+    polars_api.set_defaults(bearer="tok")
+
+    df = pl.DataFrame({"url": ["http://x/p1"]})
+    df.with_columns(pl.col("url").api.paginate(max_pages=1).alias("pages")).collect_schema()
+
+    assert seen == ["Bearer tok"]
 
 
 def test_paginate_custom_next_url(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Talking to an authenticated API meant passing client=/auth=/bearer= to
every .api call. Add a module-level configuration mechanism so those
options can be set once and reused.

- set_defaults(**options) registers persistent defaults
- get_defaults() returns the current config
- reset_defaults(*names) clears all or named defaults
- defaults(**options) context manager scopes overrides to a block

Every verb (get/post/aget/.../paginate) now resolves each unset argument
against the configured default, then the built-in default; explicit
per-call arguments always win. An UNSET sentinel distinguishes "not
passed" from an explicit None. Unknown option names raise ValueError.

Closes #21

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016dW2qGRZsDLAPpsbeSrQwd