### PR TITLE
docs: fix str.json_decode() examples for required dtype (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,19 @@
 import polars as pl
 import polars_api  # noqa: F401  — registers the `.api` namespace
 
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 (
     pl.DataFrame({"url": ["https://jsonplaceholder.typicode.com/posts/1"]})
       .with_columns(
-          pl.col("url").api.get().str.json_decode().alias("response")
+          pl.col("url").api.get().str.json_decode(post).alias("response")
       )
 )
 ```
+
+> In an expression, `str.json_decode()` needs an explicit `dtype` (recent Polars
+> made it required). See [Decoding JSON responses](#6-decoding-json-responses)
+> for the schema-free, eager alternative.
 
 - **Repository**: <https://github.com/diegoglozano/polars-api>
 - **Documentation**: <https://diegoglozano.github.io/polars-api/>
@@ -71,20 +77,23 @@ Requires Python 3.9+ and Polars 1.0+.
 import polars as pl
 import polars_api  # noqa: F401
 
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 df = (
     pl.DataFrame({"id": [1, 2, 3]})
       .with_columns(
           ("https://jsonplaceholder.typicode.com/posts/" + pl.col("id").cast(pl.Utf8)).alias("url")
       )
       .with_columns(
-          pl.col("url").api.get().str.json_decode().alias("response")
+          pl.col("url").api.get().str.json_decode(post).alias("response")
       )
 )
 ```
 
 ### 2. GET with query parameters
 
-Pass any Polars expression that resolves to a struct as `params`:
+Pass any Polars expression that resolves to a struct as `params`. Here the
+endpoint returns a JSON array, so the decode schema is `pl.List(post)`:
 
 ```python
 df = (
@@ -93,7 +102,7 @@ df = (
           pl.struct(userId=pl.Series([1, 2, 3])).alias("params"),
       )
       .with_columns(
-          pl.col("url").api.get(params=pl.col("params")).str.json_decode().alias("response")
+          pl.col("url").api.get(params=pl.col("params")).str.json_decode(pl.List(post)).alias("response")
       )
 )
 ```
@@ -101,6 +110,8 @@ df = (
 ### 3. POST with a JSON body
 
 ```python
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 df = (
     pl.DataFrame({"url": ["https://jsonplaceholder.typicode.com/posts"] * 3})
       .with_columns(
@@ -111,7 +122,7 @@ df = (
           ).alias("body"),
       )
       .with_columns(
-          pl.col("url").api.post(body=pl.col("body")).str.json_decode().alias("response")
+          pl.col("url").api.post(body=pl.col("body")).str.json_decode(post).alias("response")
       )
 )
 ```
@@ -121,10 +132,12 @@ df = (
 `aget` and `apost` fan out with `aiohttp` and `asyncio.gather`, so requests run concurrently per batch. In benchmarks against a local server, this is roughly an order of magnitude faster than the sync path at high concurrency:
 
 ```python
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 df = (
     pl.DataFrame({"url": ["https://jsonplaceholder.typicode.com/posts"] * 100})
       .with_columns(
-          pl.col("url").api.aget().str.json_decode().alias("response")
+          pl.col("url").api.aget().str.json_decode(pl.List(post)).alias("response")
       )
 )
 ```
@@ -137,6 +150,40 @@ Every method accepts a `timeout` (in seconds). Sync verbs forward it to `httpx`;
 pl.col("url").api.get(timeout=5.0)
 pl.col("url").api.apost(body=pl.col("body"), timeout=10.0)
 ```
+
+### 6. Decoding JSON responses
+
+Every verb returns a `Utf8` column of raw response bodies. There are two ways to
+parse it, depending on the context:
+
+**In an expression (works in both `DataFrame` and `LazyFrame`)** — pass an
+explicit `dtype`. Recent versions of Polars made the `dtype` argument of
+`Expr.str.json_decode()` required, because the lazy engine needs to know the
+output schema up front:
+
+```python
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
+df.with_columns(
+    pl.col("response").str.json_decode(post)
+)
+```
+
+If the endpoint returns a JSON array, wrap the element schema in `pl.List(...)`
+(e.g. `pl.List(post)`).
+
+**On a materialized `Series` (eager `DataFrame` only)** — `Series.str.json_decode()`
+can still infer the schema from the data, so you can skip the explicit dtype.
+This is convenient for quick, interactive exploration:
+
+```python
+df = df.with_columns(
+    df["response"].str.json_decode().alias("response")
+)
+```
+
+Inference only works on an already-collected `DataFrame`; inside a `LazyFrame`
+pipeline you must use the expression form with an explicit dtype.
 
 ## API reference
 
@@ -179,7 +226,9 @@ By default, each method returns a `pl.Expr` of `Utf8`. With `with_metadata=True`
 {"body": Utf8, "status": Int64, "elapsed_ms": Float64, "error": Utf8}
 ```
 
-Use `.str.json_decode()` to parse JSON responses.
+See [Decoding JSON responses](#6-decoding-json-responses) for how to parse the
+body — pass an explicit `dtype` in an expression, or call `.str.json_decode()`
+on the materialized `Series` to infer the schema.
 
 ### Examples
 
@@ -257,7 +306,7 @@ endpoint, network RTT will dominate and the gap between clients shrinks.
 
 ## Tips and patterns
 
-- **Decode JSON immediately**: chain `.str.json_decode()` and then `.struct.unnest()` (or `pl.col("response").struct.field("…")`) to flatten the result.
+- **Decode JSON immediately**: chain `.str.json_decode(dtype)` (an explicit schema is required in an expression — see [Decoding JSON responses](#6-decoding-json-responses)) and then `.struct.unnest()` (or `pl.col("response").struct.field("…")`) to flatten the result.
 - **Build URLs from columns**: use Polars string concatenation or `pl.format("https://api.example.com/users/{}", pl.col("user_id"))` to build per-row URLs.
 - **Prefer `aget` / `apost` for many rows**: async variants run requests concurrently and are typically much faster for I/O-bound workloads.
 - **Inspect failures**: the sync helpers return `null` for non-2xx responses; check for nulls in the resulting column before decoding.
@@ -277,7 +326,7 @@ Yes. `aget` and `apost` issue requests concurrently with `asyncio.gather`, which
 Yes — because everything is built on Polars expressions, you can use it in `LazyFrame.with_columns(...)` pipelines.
 
 **What does it return?**
-A `Utf8` column with the raw response body. Pipe it through `.str.json_decode()` to parse JSON responses.
+A `Utf8` column with the raw response body. Parse it with `.str.json_decode(dtype)` in an expression, or call `.str.json_decode()` on the materialized `Series` to infer the schema — see [Decoding JSON responses](#6-decoding-json-responses).
 
 ## Contributing
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -21,7 +21,7 @@ import polars_api  # noqa: F401  — registers the `.api` namespace
 | [`post`](#polars_api.api.Api.post)   | POST      | sync  |
 | [`apost`](#polars_api.api.Api.apost) | POST      | async |
 
-All methods return a `pl.Expr` of dtype `Utf8` containing the response body for each row. Use `.str.json_decode()` to parse JSON responses.
+All methods return a `pl.Expr` of dtype `Utf8` containing the response body for each row. To parse JSON, pass an explicit schema to `.str.json_decode(dtype)` in an expression (recent Polars makes the `dtype` argument required), or call `.str.json_decode()` on the materialized `Series` to infer the schema. See [Decoding JSON responses](index.md#decoding-json-responses).
 
 ## `polars_api.Api`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,13 +23,19 @@ description: Call REST APIs from a Polars DataFrame, one row at a time, using na
 import polars as pl
 import polars_api  # noqa: F401  — registers the `.api` namespace
 
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 (
     pl.DataFrame({"url": ["https://jsonplaceholder.typicode.com/posts/1"]})
       .with_columns(
-          pl.col("url").api.get().str.json_decode().alias("response")
+          pl.col("url").api.get().str.json_decode(post).alias("response")
       )
 )
 ```
+
+> In an expression, `str.json_decode()` requires an explicit `dtype` (recent
+> Polars made it mandatory). See [Decoding JSON responses](#decoding-json-responses)
+> for the schema-free, eager alternative.
 
 ## Why polars-api?
 
@@ -57,13 +63,15 @@ Requires Python 3.9+ and Polars 1.0+.
 import polars as pl
 import polars_api  # noqa: F401
 
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 (
     pl.DataFrame({"id": [1, 2, 3]})
       .with_columns(
           ("https://jsonplaceholder.typicode.com/posts/" + pl.col("id").cast(pl.Utf8)).alias("url")
       )
       .with_columns(
-          pl.col("url").api.get().str.json_decode().alias("response")
+          pl.col("url").api.get().str.json_decode(post).alias("response")
       )
 )
 ```
@@ -71,6 +79,8 @@ import polars_api  # noqa: F401
 ### POST with a JSON body
 
 ```python
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
 (
     pl.DataFrame({"url": ["https://jsonplaceholder.typicode.com/posts"] * 3})
       .with_columns(
@@ -81,10 +91,36 @@ import polars_api  # noqa: F401
           ).alias("body"),
       )
       .with_columns(
-          pl.col("url").api.post(body=pl.col("body")).str.json_decode().alias("response")
+          pl.col("url").api.post(body=pl.col("body")).str.json_decode(post).alias("response")
       )
 )
 ```
+
+### Decoding JSON responses
+
+Every verb returns a `Utf8` column of raw response bodies. There are two ways to
+parse it:
+
+- **In an expression (`DataFrame` and `LazyFrame`)** — pass an explicit `dtype`.
+  Recent Polars made `Expr.str.json_decode()`'s `dtype` required, since the lazy
+  engine needs the output schema up front. Wrap the element schema in
+  `pl.List(...)` when the endpoint returns a JSON array:
+
+  ```python
+  post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
+
+  df.with_columns(pl.col("response").str.json_decode(post))
+  ```
+
+- **On a materialized `Series` (eager `DataFrame` only)** —
+  `Series.str.json_decode()` can still infer the schema from the data:
+
+  ```python
+  df = df.with_columns(df["response"].str.json_decode().alias("response"))
+  ```
+
+  Inference only works on a collected `DataFrame`; inside a `LazyFrame` pipeline
+  use the expression form with an explicit dtype.
 
 ### Async for throughput
 
@@ -102,7 +138,7 @@ pl.col("url").api.apost(body=pl.col("body"))  # concurrent POST
 | `post`  | POST      | sync  |
 | `apost` | POST      | async |
 
-All methods accept optional `params` (struct expression for query string), `timeout` (seconds), and POST methods additionally accept `body` (struct expression serialized as JSON). Each returns a `Utf8` expression with the response body — pipe it through `.str.json_decode()` to parse JSON.
+All methods accept optional `params` (struct expression for query string), `timeout` (seconds), and POST methods additionally accept `body` (struct expression serialized as JSON). Each returns a `Utf8` expression with the response body — parse it with [`.str.json_decode()`](#decoding-json-responses).
 
 See the full [API reference](documentation.md).
 

--- a/examples/example.py
+++ b/examples/example.py
@@ -3,6 +3,11 @@ import polars as pl
 import polars_api  # noqa:F401
 
 BASE_URL = "https://jsonplaceholder.typicode.com/posts"
+
+# In an expression, `str.json_decode` requires an explicit schema. The /posts
+# collection endpoint returns a JSON array, while POST /posts returns the single
+# created object.
+post = pl.Struct({"userId": pl.Int64, "id": pl.Int64, "title": pl.Utf8, "body": pl.Utf8})
 print(
     pl.DataFrame({
         "url": [BASE_URL for _ in range(10)],
@@ -18,11 +23,11 @@ print(
         ).alias("body"),
     )
     .with_columns(
-        pl.col("url").api.get().str.json_decode().alias("get"),
-        pl.col("url").api.aget().str.json_decode().alias("aget"),
-        pl.col("url").api.get(params=pl.col("params")).str.json_decode().alias("get_params"),
-        pl.col("url").api.post(body=pl.col("body")).str.json_decode().alias("post"),
-        pl.col("url").api.apost(body=pl.col("body")).str.json_decode().alias("apost"),
+        pl.col("url").api.get().str.json_decode(pl.List(post)).alias("get"),
+        pl.col("url").api.aget().str.json_decode(pl.List(post)).alias("aget"),
+        pl.col("url").api.get(params=pl.col("params")).str.json_decode(pl.List(post)).alias("get_params"),
+        pl.col("url").api.post(body=pl.col("body")).str.json_decode(post).alias("post"),
+        pl.col("url").api.apost(body=pl.col("body")).str.json_decode(post).alias("apost"),
         pl.col("url").api.apost(params=pl.col("params")).alias("apost_params"),
     )
 )

--- a/polars_api/api.py
+++ b/polars_api/api.py
@@ -946,8 +946,9 @@ class Api:
         """Synchronously paginate per row, following Link: rel="next" by default.
 
         Returns a column of List[Utf8] — one list of response bodies per starting
-        URL. Pipe through `.list.eval(pl.element().str.json_decode())` and `.explode(...)`
-        to flatten paginated rows back into the DataFrame.
+        URL. Pipe through `.list.eval(pl.element().str.json_decode(dtype))` and
+        `.explode(...)` to flatten paginated rows back into the DataFrame (the
+        `dtype` schema is required when decoding inside an expression).
 
         Pass `next_url=lambda response: ...` to extract the next URL from a custom
         location (e.g. a JSON field) instead of the Link header.


### PR DESCRIPTION
Fixes #20.

## Problem

Recent Polars made the `dtype` argument of `Expr.str.json_decode()` **required**, so every documented example that chained `.str.json_decode()` inside an expression now raises:

```
TypeError: ExprStringNameSpace.json_decode() missing 1 required positional argument: 'dtype'
```

`Series.str.json_decode()` still infers the schema, which is why the materialized-column form keeps working.

## Changes

- Pass an explicit `dtype` in all in-expression examples (`README.md`, `docs/index.md`, `examples/example.py`, and the `paginate` docstring), using `pl.List(...)` where the endpoint returns a JSON array (`/posts`).
- Add a **"Decoding JSON responses"** section to the README and docs site documenting both approaches:
  - **Expression + explicit `dtype`** — works in `DataFrame` *and* `LazyFrame`.
  - **`Series.str.json_decode()`** — infers the schema, eager `DataFrame` only.

## Verification

Confirmed both forms round-trip on the project's pinned polars **1.19.0** and the latest **1.41.2**. `examples/example.py` compiles and `ruff check` / `ruff format --check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXC16nLNMCaa3vRY5MZv7n

---
_Generated by [Claude Code](https://claude.ai/code/session_01QXC16nLNMCaa3vRY5MZv7n)_